### PR TITLE
Add chart builder interface for análise JP workflows

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,6 +8,7 @@ from flask_migrate import Migrate
 from config import Config
 from app.models.user import db, User
 from app.models.dashboard import Dashboard
+from app.models.analise_jp_chart import AnaliseJPChart
 from app.models.workflow import Workflow
 from app.services.auth_service import init_bcrypt
 

--- a/app/models/analise_jp_chart.py
+++ b/app/models/analise_jp_chart.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+
+from app import db
+
+
+class AnaliseJPChart(db.Model):
+    __tablename__ = 'analise_jp_charts'
+
+    id = db.Column(db.Integer, primary_key=True)
+    workflow_id = db.Column(db.Integer, db.ForeignKey('workflows.id'), nullable=False, index=True)
+    categoria = db.Column(db.String(120), nullable=False)
+    nome = db.Column(db.String(150), nullable=False)
+    chart_type = db.Column(db.String(50), nullable=False)
+    dimension_field = db.Column(db.String(150), nullable=False)
+    value_fields = db.Column(db.JSON, nullable=False)
+    options = db.Column(db.JSON, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    workflow = db.relationship(
+        'Workflow',
+        backref=db.backref('analise_jp_charts', lazy='dynamic', cascade='all, delete-orphan')
+    )
+
+    def __repr__(self) -> str:
+        return f"<AnaliseJPChart {self.chart_type} ({self.categoria})>"
+
+    def to_dict(self) -> dict:
+        return {
+            'id': self.id,
+            'workflow_id': self.workflow_id,
+            'categoria': self.categoria,
+            'nome': self.nome,
+            'chart_type': self.chart_type,
+            'dimension_field': self.dimension_field,
+            'value_fields': list(self.value_fields or []),
+            'options': self.options or {},
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/app/routes/analise_jp.py
+++ b/app/routes/analise_jp.py
@@ -1,7 +1,7 @@
 import io
 from datetime import datetime
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 import pandas as pd
 from flask import Blueprint, current_app, jsonify, redirect, render_template, request, url_for
@@ -11,6 +11,7 @@ from werkzeug.utils import secure_filename
 
 from app import db
 from app.models.analise_upload import AnaliseUpload
+from app.models.analise_jp_chart import AnaliseJPChart
 from app.models.workflow import Workflow
 from app.services.theme_service import get_theme_context
 
@@ -35,6 +36,10 @@ ANALISE_JP_CATEGORIES: List[str] = [
 
 ALLOWED_EXTENSIONS = {'.csv', '.xlsx'}
 
+ANALISE_JP_ALLOWED_CHART_TYPES = {
+    'bar', 'line', 'pie', 'doughnut', 'radar'
+}
+
 
 def _get_workflow_or_404(workflow_id: int) -> Workflow:
     return Workflow.query.filter_by(id=workflow_id, usuario_id=current_user.id).first_or_404()
@@ -43,6 +48,20 @@ def _get_workflow_or_404(workflow_id: int) -> Workflow:
 def _validate_category(categoria: str) -> None:
     if categoria not in ANALISE_JP_CATEGORIES:
         raise ValueError('Categoria invalida.')
+
+
+def _slug_to_label(slug: str) -> str:
+    parts = [part.capitalize() for part in slug.split('_') if part]
+    return ' '.join(parts) if parts else slug
+
+
+def _get_latest_upload_for_category(workflow_id: int, categoria: str) -> Optional[AnaliseUpload]:
+    return (
+        AnaliseUpload.query
+        .filter_by(workflow_id=workflow_id, categoria=categoria)
+        .order_by(AnaliseUpload.created_at.desc())
+        .first()
+    )
 
 
 def _decode_csv_bytes(data: bytes) -> io.StringIO:
@@ -156,6 +175,46 @@ def analise_jp_view(workflow_id: int):
     )
 
 
+@analise_jp_bp.route('/analise_jp/<int:workflow_id>/graficos')
+@login_required
+def analise_jp_charts_view(workflow_id: int):
+    workflow = _get_workflow_or_404(workflow_id)
+    if workflow.tipo != 'analise_jp':
+        return redirect(url_for('workflow.workflow_view', workflow_nome=workflow.nome))
+
+    theme = get_theme_context()
+
+    categories_meta = []
+    for categoria in ANALISE_JP_CATEGORIES:
+        latest_upload = _get_latest_upload_for_category(workflow.id, categoria)
+        categories_meta.append({
+            'slug': categoria,
+            'label': _slug_to_label(categoria),
+            'has_data': bool(latest_upload and latest_upload.dados_extraidos),
+            'latest_upload': None if not latest_upload else {
+                'id': latest_upload.id,
+                'nome_arquivo': latest_upload.nome_arquivo,
+                'created_at': latest_upload.created_at.isoformat() if latest_upload.created_at else None
+            }
+        })
+
+    charts = (
+        AnaliseJPChart.query
+        .filter_by(workflow_id=workflow.id)
+        .order_by(AnaliseJPChart.created_at.desc())
+        .all()
+    )
+
+    return render_template(
+        'analise_jp_charts.html',
+        workflow=workflow,
+        theme=theme,
+        categories_meta=categories_meta,
+        allowed_chart_types=sorted(ANALISE_JP_ALLOWED_CHART_TYPES),
+        charts=[chart.to_dict() for chart in charts]
+    )
+
+
 @analise_jp_bp.route('/analise_jp/<int:workflow_id>/uploads/<string:categoria>', methods=['GET'])
 @login_required
 def listar_uploads(workflow_id: int, categoria: str):
@@ -173,6 +232,40 @@ def listar_uploads(workflow_id: int, categoria: str):
     )
 
     return jsonify({'uploads': [upload.to_dict() for upload in uploads]})
+
+
+@analise_jp_bp.route('/analise_jp/<int:workflow_id>/api/categorias/<string:categoria>/dataset', methods=['GET'])
+@login_required
+def obter_dataset_categoria(workflow_id: int, categoria: str):
+    workflow = _get_workflow_or_404(workflow_id)
+    try:
+        _validate_category(categoria)
+    except ValueError as exc:
+        return jsonify({'error': str(exc)}), 400
+
+    upload = _get_latest_upload_for_category(workflow.id, categoria)
+    if not upload or not upload.dados_extraidos:
+        return jsonify({'error': 'Nenhum upload encontrado para a categoria selecionada.'}), 404
+
+    records = upload.dados_extraidos if isinstance(upload.dados_extraidos, list) else []
+    fields: List[str] = []
+    for record in records:
+        if isinstance(record, dict):
+            fields = list(record.keys())
+            break
+
+    return jsonify({
+        'categoria': categoria,
+        'categoria_label': _slug_to_label(categoria),
+        'record_count': len(records),
+        'fields': fields,
+        'records': records,
+        'upload': {
+            'id': upload.id,
+            'nome_arquivo': upload.nome_arquivo,
+            'created_at': upload.created_at.isoformat() if upload.created_at else None
+        }
+    })
 
 
 @analise_jp_bp.route('/analise_jp/<int:workflow_id>/upload/<string:categoria>', methods=['POST'])
@@ -257,3 +350,139 @@ def excluir_upload(workflow_id: int, categoria: str, upload_id: int):
     db.session.commit()
 
     return jsonify({'message': 'Upload removido com sucesso.'}), 200
+
+
+@analise_jp_bp.route('/analise_jp/<int:workflow_id>/api/graficos', methods=['GET'])
+@login_required
+def listar_graficos_analise_jp(workflow_id: int):
+    workflow = _get_workflow_or_404(workflow_id)
+    charts = (
+        AnaliseJPChart.query
+        .filter_by(workflow_id=workflow.id)
+        .order_by(AnaliseJPChart.created_at.desc())
+        .all()
+    )
+
+    return jsonify([chart.to_dict() for chart in charts])
+
+
+@analise_jp_bp.route('/analise_jp/<int:workflow_id>/api/graficos', methods=['POST'])
+@login_required
+def criar_grafico_analise_jp(workflow_id: int):
+    workflow = _get_workflow_or_404(workflow_id)
+    if workflow.tipo != 'analise_jp':
+        return jsonify({'error': 'Workflow nao suporta graficos para este tipo.'}), 400
+
+    payload = request.get_json() or {}
+
+    categoria = (payload.get('categoria') or '').strip()
+    if not categoria:
+        return jsonify({'error': 'Categoria obrigatoria.'}), 400
+    try:
+        _validate_category(categoria)
+    except ValueError as exc:
+        return jsonify({'error': str(exc)}), 400
+
+    chart_type = (payload.get('chart_type') or '').strip().lower()
+    if chart_type not in ANALISE_JP_ALLOWED_CHART_TYPES:
+        return jsonify({'error': 'Tipo de grafico invalido.'}), 400
+
+    dimension_field = (payload.get('dimension_field') or '').strip()
+    if not dimension_field:
+        return jsonify({'error': 'Selecione um campo para o eixo principal.'}), 400
+
+    raw_values = payload.get('value_fields') or payload.get('series') or []
+    if isinstance(raw_values, str):
+        raw_values = [raw_values]
+    value_fields: List[str] = []
+    for item in raw_values:
+        if isinstance(item, str):
+            cleaned = item.strip()
+            if cleaned and cleaned not in value_fields:
+                value_fields.append(cleaned)
+
+    if not value_fields:
+        return jsonify({'error': 'Selecione ao menos um campo de valor.'}), 400
+
+    upload = _get_latest_upload_for_category(workflow.id, categoria)
+    if not upload or not upload.dados_extraidos:
+        return jsonify({'error': 'Nenhum dado disponivel para a categoria selecionada.'}), 400
+
+    records = upload.dados_extraidos if isinstance(upload.dados_extraidos, list) else []
+    if not records:
+        return jsonify({'error': 'Nenhum dado processado encontrado para a categoria.'}), 400
+
+    available_fields = set()
+    for record in records:
+        if isinstance(record, dict):
+            available_fields.update(record.keys())
+
+    if dimension_field not in available_fields:
+        return jsonify({'error': 'Campo de eixo invalido para a categoria selecionada.'}), 400
+
+    missing_fields = [field for field in value_fields if field not in available_fields]
+    if missing_fields:
+        return jsonify({'error': f"Campos nao encontrados na base: {', '.join(missing_fields)}"}), 400
+
+    nome = (payload.get('nome') or payload.get('title') or '').strip()
+    if not nome:
+        nome = f"{_slug_to_label(categoria)} - {chart_type.title()}"
+
+    options = payload.get('options') or {}
+    if not isinstance(options, dict):
+        options = {}
+
+    colors = payload.get('colors') or []
+    if isinstance(colors, list):
+        cleaned_colors = [
+            color.strip() for color in colors
+            if isinstance(color, str) and color.strip()
+        ]
+        if cleaned_colors:
+            options['colors'] = cleaned_colors
+
+    novo_grafico = AnaliseJPChart(
+        workflow_id=workflow.id,
+        categoria=categoria,
+        nome=nome,
+        chart_type=chart_type,
+        dimension_field=dimension_field,
+        value_fields=value_fields,
+        options=options
+    )
+
+    try:
+        db.session.add(novo_grafico)
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        return jsonify({'error': 'Nao foi possivel salvar o grafico.'}), 500
+
+    return jsonify({
+        'message': 'Grafico criado com sucesso.',
+        'grafico': novo_grafico.to_dict()
+    }), 201
+
+
+@analise_jp_bp.route('/analise_jp/<int:workflow_id>/api/graficos/<int:grafico_id>', methods=['DELETE'])
+@login_required
+def excluir_grafico_analise_jp(workflow_id: int, grafico_id: int):
+    workflow = _get_workflow_or_404(workflow_id)
+
+    grafico = (
+        AnaliseJPChart.query
+        .filter_by(id=grafico_id, workflow_id=workflow.id)
+        .first()
+    )
+
+    if not grafico:
+        return jsonify({'error': 'Grafico nao encontrado.'}), 404
+
+    try:
+        db.session.delete(grafico)
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        return jsonify({'error': 'Nao foi possivel remover o grafico.'}), 500
+
+    return jsonify({'message': 'Grafico removido com sucesso.'})

--- a/app/static/js/analise_jp_charts.js
+++ b/app/static/js/analise_jp_charts.js
@@ -1,0 +1,826 @@
+const ctx = window.__ANALISE_JP__ || {};
+
+const state = {
+    charts: Array.isArray(ctx.charts) ? [...ctx.charts] : [],
+    datasets: new Map(),
+    pendingDelete: null,
+    selectAllActive: false
+};
+
+const chartInstances = new Map();
+
+const elements = {
+    chartsGrid: document.getElementById('chartsGrid'),
+    chartsEmptyState: document.getElementById('chartsEmptyState'),
+    chartsSubtitle: document.getElementById('chartsSubtitle'),
+    openModalBtn: document.getElementById('openCreateChartBtn'),
+    emptyStateCreateBtn: document.getElementById('emptyStateCreateBtn'),
+    refreshBtn: document.getElementById('refreshChartsBtn'),
+    chartModal: document.getElementById('chartModal'),
+    chartModalOverlay: document.getElementById('chartModalOverlay'),
+    closeModalBtn: document.getElementById('closeChartModalBtn'),
+    cancelModalBtn: document.getElementById('cancelChartBtn'),
+    chartForm: document.getElementById('chartForm'),
+    chartTitle: document.getElementById('chartTitle'),
+    chartType: document.getElementById('chartType'),
+    chartCategory: document.getElementById('chartCategory'),
+    categoryHint: document.getElementById('categoryHint'),
+    dimensionField: document.getElementById('dimensionField'),
+    valueFieldOptions: document.getElementById('valueFieldOptions'),
+    valueFieldEmpty: document.getElementById('valueFieldEmpty'),
+    fieldLoadingState: document.getElementById('fieldLoadingState'),
+    toggleSelectAllValues: document.getElementById('toggleSelectAllValues'),
+    formFeedback: document.getElementById('chartFormFeedback'),
+    submitBtn: document.getElementById('submitChartBtn'),
+    submitSpinner: document.getElementById('submitChartSpinner'),
+    toastContainer: document.getElementById('toastContainer'),
+    deleteModal: document.getElementById('deleteModal'),
+    deleteModalOverlay: document.getElementById('deleteModalOverlay'),
+    deleteMessage: document.getElementById('deleteModalMessage'),
+    confirmDeleteBtn: document.getElementById('confirmDeleteBtn'),
+    deleteSpinner: document.getElementById('deleteSpinner'),
+    cancelDeleteBtn: document.getElementById('cancelDeleteBtn'),
+    closeDeleteModalBtn: document.getElementById('closeDeleteModalBtn')
+};
+
+const DEFAULT_PALETTE = ['#38BDF8', '#22D3EE', '#A855F7', '#F97316', '#FACC15', '#34D399'];
+
+function slugToLabel(slug) {
+    if (!slug) return '';
+    return slug
+        .split('_')
+        .filter(Boolean)
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+}
+
+function getPalette() {
+    if (Array.isArray(ctx.themePalette) && ctx.themePalette.length) {
+        return ctx.themePalette;
+    }
+    return DEFAULT_PALETTE;
+}
+
+function showToast(message, type = 'success') {
+    if (!elements.toastContainer) return;
+    const toast = document.createElement('div');
+    const baseClass = 'glass-panel border border-white/10 rounded-2xl px-4 py-3 text-sm shadow-lg flex items-center gap-3';
+    const themeClass = type === 'error'
+        ? (ctx.themeClasses?.toastError || 'bg-rose-600 text-white')
+        : (ctx.themeClasses?.toastSuccess || 'bg-emerald-600 text-white');
+    toast.className = `${baseClass} ${themeClass}`;
+    toast.textContent = message;
+    elements.toastContainer.appendChild(toast);
+    setTimeout(() => {
+        toast.classList.add('opacity-0', 'translate-y-2');
+        setTimeout(() => toast.remove(), 220);
+    }, 3200);
+}
+
+function setFormFeedback(message) {
+    if (!elements.formFeedback) return;
+    if (!message) {
+        elements.formFeedback.classList.add('hidden');
+        elements.formFeedback.textContent = '';
+        return;
+    }
+    elements.formFeedback.textContent = message;
+    elements.formFeedback.classList.remove('hidden');
+}
+
+function setSubmitLoading(isLoading) {
+    if (!elements.submitBtn) return;
+    elements.submitBtn.disabled = isLoading;
+    if (elements.submitSpinner) {
+        elements.submitSpinner.classList.toggle('hidden', !isLoading);
+    }
+}
+
+function setDeleteLoading(isLoading) {
+    if (!elements.confirmDeleteBtn) return;
+    elements.confirmDeleteBtn.disabled = isLoading;
+    if (elements.deleteSpinner) {
+        elements.deleteSpinner.classList.toggle('hidden', !isLoading);
+    }
+}
+
+function closeModal() {
+    if (!elements.chartModal) return;
+    elements.chartModal.classList.add('hidden');
+    setFormFeedback('');
+    state.selectAllActive = false;
+}
+
+function openModal() {
+    if (!elements.chartModal) return;
+    populateChartTypes();
+    populateCategorySelect();
+    elements.chartTitle.value = '';
+    setFormFeedback('');
+    setSubmitLoading(false);
+    const firstAvailable = Array.from(elements.chartCategory.options).find((option) => !option.disabled && option.value);
+    if (firstAvailable) {
+        elements.chartCategory.value = firstAvailable.value;
+        updateCategoryHint(firstAvailable.value);
+        loadFieldsForCategory(firstAvailable.value);
+    } else {
+        elements.chartCategory.value = '';
+        updateCategoryHint('');
+        clearFieldSelectors();
+    }
+    elements.chartModal.classList.remove('hidden');
+}
+
+function openDeleteModal(chart) {
+    if (!elements.deleteModal) return;
+    state.pendingDelete = chart?.id || null;
+    if (elements.deleteMessage) {
+        elements.deleteMessage.textContent = chart?.nome
+            ? `Tem certeza que deseja remover o gráfico "${chart.nome}"?`
+            : 'Tem certeza que deseja remover este gráfico?';
+    }
+    setDeleteLoading(false);
+    elements.deleteModal.classList.remove('hidden');
+}
+
+function closeDeleteModal() {
+    if (!elements.deleteModal) return;
+    state.pendingDelete = null;
+    setDeleteLoading(false);
+    elements.deleteModal.classList.add('hidden');
+}
+
+function populateChartTypes() {
+    if (!elements.chartType) return;
+    elements.chartType.innerHTML = '';
+    const types = Array.isArray(ctx.allowedChartTypes) && ctx.allowedChartTypes.length
+        ? ctx.allowedChartTypes
+        : ['bar', 'line', 'pie', 'doughnut', 'radar'];
+    types.forEach((type) => {
+        const option = document.createElement('option');
+        option.value = type;
+        option.textContent = slugToLabel(type.replace('polararea', 'polar_area'));
+        elements.chartType.appendChild(option);
+    });
+}
+
+function populateCategorySelect() {
+    if (!elements.chartCategory) return;
+    elements.chartCategory.innerHTML = '';
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'Selecione uma categoria';
+    placeholder.disabled = true;
+    placeholder.selected = true;
+    elements.chartCategory.appendChild(placeholder);
+
+    const categories = Array.isArray(ctx.categories) ? ctx.categories : [];
+    categories.forEach((category) => {
+        const option = document.createElement('option');
+        option.value = category.slug;
+        option.textContent = category.label || slugToLabel(category.slug);
+        if (!category.has_data) {
+            option.disabled = true;
+            option.textContent += ' • sem dados';
+        }
+        elements.chartCategory.appendChild(option);
+    });
+}
+
+function updateCategoryHint(slug) {
+    if (!elements.categoryHint) return;
+    const categories = Array.isArray(ctx.categories) ? ctx.categories : [];
+    const entry = categories.find((item) => item.slug === slug);
+    if (!entry) {
+        elements.categoryHint.textContent = '';
+        return;
+    }
+    if (!entry.has_data) {
+        elements.categoryHint.textContent = 'Nenhum upload disponível para esta categoria.';
+        return;
+    }
+    if (entry.latest_upload?.nome_arquivo) {
+        const uploadedAt = entry.latest_upload.created_at
+            ? new Date(entry.latest_upload.created_at).toLocaleString('pt-BR')
+            : '';
+        elements.categoryHint.textContent = uploadedAt
+            ? `Último upload: ${entry.latest_upload.nome_arquivo} em ${uploadedAt}`
+            : `Último upload: ${entry.latest_upload.nome_arquivo}`;
+    } else {
+        elements.categoryHint.textContent = 'Dados disponíveis para criar gráficos.';
+    }
+}
+
+function clearFieldSelectors() {
+    if (elements.dimensionField) {
+        elements.dimensionField.innerHTML = '<option value="">Selecione uma categoria</option>';
+        elements.dimensionField.disabled = true;
+    }
+    if (elements.valueFieldOptions) {
+        elements.valueFieldOptions.innerHTML = '';
+    }
+    if (elements.valueFieldEmpty) {
+        elements.valueFieldEmpty.classList.add('hidden');
+    }
+    if (elements.toggleSelectAllValues) {
+        elements.toggleSelectAllValues.classList.add('hidden');
+    }
+}
+
+function setFieldLoading(isLoading) {
+    if (elements.fieldLoadingState) {
+        elements.fieldLoadingState.classList.toggle('hidden', !isLoading);
+    }
+}
+
+function buildDatasetUrl(category) {
+    let endpoint = ctx.endpoints?.dataset || '';
+    if (!endpoint) return '';
+    return endpoint.replace('__categoria__', encodeURIComponent(category));
+}
+
+async function fetchDataset(category, { force = false } = {}) {
+    if (!category) return null;
+    if (!force && state.datasets.has(category)) {
+        return state.datasets.get(category);
+    }
+    const url = buildDatasetUrl(category);
+    if (!url) return null;
+    const response = await fetch(url);
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+        throw new Error(data?.error || 'Falha ao carregar dados da categoria.');
+    }
+    state.datasets.set(category, data);
+    return data;
+}
+
+function createValueCheckbox(field, index, defaults = []) {
+    const wrapper = document.createElement('label');
+    wrapper.className = 'flex items-center gap-3 rounded-xl px-3 py-2 hover:bg-white/10 transition-colors cursor-pointer';
+
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.value = field;
+    input.checked = defaults.includes(field);
+    input.className = 'h-4 w-4 rounded border-white/20 bg-transparent';
+
+    const name = document.createElement('span');
+    name.className = 'text-sm text-white/80 truncate';
+    name.textContent = field;
+
+    wrapper.appendChild(input);
+    wrapper.appendChild(name);
+    return wrapper;
+}
+
+function detectDefaultValues(fields, dimension) {
+    const filtered = fields.filter((field) => field !== dimension);
+    return filtered.slice(0, 2);
+}
+
+async function loadFieldsForCategory(category) {
+    clearFieldSelectors();
+    if (!category) return;
+    setFieldLoading(true);
+    try {
+        const dataset = await fetchDataset(category);
+        const fields = Array.isArray(dataset?.fields) ? dataset.fields : [];
+        const records = Array.isArray(dataset?.records) ? dataset.records : [];
+
+        if (!fields.length || !records.length) {
+            if (elements.valueFieldEmpty) {
+                elements.valueFieldEmpty.classList.remove('hidden');
+                elements.valueFieldEmpty.textContent = 'Nenhum dado disponível para esta categoria.';
+            }
+            return;
+        }
+
+        if (elements.dimensionField) {
+            elements.dimensionField.disabled = false;
+            elements.dimensionField.innerHTML = '';
+            fields.forEach((field, index) => {
+                const option = document.createElement('option');
+                option.value = field;
+                option.textContent = field;
+                if (index === 0) {
+                    option.selected = true;
+                }
+                elements.dimensionField.appendChild(option);
+            });
+        }
+
+        const defaults = detectDefaultValues(fields, elements.dimensionField?.value || fields[0]);
+        if (elements.valueFieldOptions) {
+            elements.valueFieldOptions.innerHTML = '';
+            fields.forEach((field, index) => {
+                const checkbox = createValueCheckbox(field, index, defaults);
+                elements.valueFieldOptions.appendChild(checkbox);
+            });
+        }
+
+        if (elements.toggleSelectAllValues) {
+            elements.toggleSelectAllValues.classList.toggle('hidden', !fields.length);
+            elements.toggleSelectAllValues.textContent = 'Selecionar todos';
+            state.selectAllActive = false;
+        }
+
+        if (elements.valueFieldEmpty) {
+            elements.valueFieldEmpty.classList.toggle('hidden', !!fields.length);
+        }
+    } catch (error) {
+        setFormFeedback(error.message);
+        clearFieldSelectors();
+    } finally {
+        setFieldLoading(false);
+    }
+}
+
+function getSelectedValueFields() {
+    if (!elements.valueFieldOptions) return [];
+    return Array.from(elements.valueFieldOptions.querySelectorAll('input[type="checkbox"]:checked'))
+        .map((input) => input.value)
+        .filter(Boolean);
+}
+
+function toggleSelectAllValues() {
+    if (!elements.valueFieldOptions) return;
+    const checkboxes = Array.from(elements.valueFieldOptions.querySelectorAll('input[type="checkbox"]'));
+    if (!checkboxes.length) return;
+    const shouldSelectAll = !state.selectAllActive;
+    checkboxes.forEach((checkbox) => {
+        checkbox.checked = shouldSelectAll;
+    });
+    state.selectAllActive = shouldSelectAll;
+    if (elements.toggleSelectAllValues) {
+        elements.toggleSelectAllValues.textContent = shouldSelectAll ? 'Limpar seleção' : 'Selecionar todos';
+    }
+}
+
+function buildDeleteUrl(chartId) {
+    const template = ctx.endpoints?.delete || '';
+    if (!template) return '';
+    if (template.endsWith('/0')) {
+        return `${template.slice(0, -1)}${chartId}`;
+    }
+    if (template.includes('/0/')) {
+        return template.replace('/0/', `/${chartId}/`);
+    }
+    return template.replace(/0$/, String(chartId));
+}
+
+function parseNumeric(value) {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : null;
+    }
+    if (typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    let normalized = trimmed.replace(/\s+/g, '');
+    if (normalized.includes(',') && normalized.includes('.')) {
+        normalized = normalized.replace(/\./g, '').replace(',', '.');
+    } else if (normalized.includes(',')) {
+        normalized = normalized.replace(',', '.');
+    }
+    const numeric = Number(normalized);
+    return Number.isFinite(numeric) ? numeric : null;
+}
+
+function prepareChartData(records, dimensionField, valueFields) {
+    const labels = [];
+    const fields = Array.isArray(valueFields) ? valueFields : [];
+    const series = fields.map(() => []);
+    records.forEach((record) => {
+        if (!record || typeof record !== 'object') return;
+        const label = record[dimensionField];
+        if (label === undefined || label === null || label === '') return;
+        labels.push(String(label));
+        fields.forEach((field, index) => {
+            const value = parseNumeric(record[field]);
+            series[index].push(value);
+        });
+    });
+    return { labels, series };
+}
+
+function hexToRgba(hex, alpha = 1) {
+    if (!hex) return `rgba(56, 189, 248, ${alpha})`;
+    const sanitized = hex.replace('#', '');
+    if (sanitized.length !== 6) {
+        return `rgba(56, 189, 248, ${alpha})`;
+    }
+    const bigint = parseInt(sanitized, 16);
+    const r = (bigint >> 16) & 255;
+    const g = (bigint >> 8) & 255;
+    const b = bigint & 255;
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function buildDatasets(chart, labels, series) {
+    const palette = Array.isArray(chart.options?.colors) && chart.options.colors.length
+        ? chart.options.colors
+        : getPalette();
+    const type = chart.chart_type || 'bar';
+    const valueFields = Array.isArray(chart.value_fields) ? chart.value_fields : [];
+
+    return valueFields.map((field, index) => {
+        const baseColor = palette[index % palette.length];
+        if (type === 'pie' || type === 'doughnut') {
+            const background = labels.map((_, labelIndex) => palette[(index + labelIndex) % palette.length]);
+            return {
+                label: field,
+                data: series[index],
+                backgroundColor: background,
+                borderWidth: 1,
+                borderColor: hexToRgba('#ffffff', 0.08)
+            };
+        }
+
+        if (type === 'radar') {
+            return {
+                label: field,
+                data: series[index],
+                fill: true,
+                backgroundColor: hexToRgba(baseColor, 0.25),
+                borderColor: baseColor,
+                pointBackgroundColor: baseColor,
+                pointBorderColor: '#fff',
+                pointHoverBorderColor: baseColor,
+                borderWidth: 2
+            };
+        }
+
+        return {
+            label: field,
+            data: series[index],
+            borderColor: baseColor,
+            backgroundColor: type === 'bar' ? hexToRgba(baseColor, 0.55) : hexToRgba(baseColor, 0.15),
+            borderWidth: 2,
+            tension: 0.35,
+            fill: type !== 'bar'
+        };
+    });
+}
+
+function renderChartInstance(chart, canvas, messageEl) {
+    if (!canvas) return;
+    const category = chart.categoria;
+    if (messageEl) {
+        messageEl.classList.add('hidden');
+        messageEl.textContent = '';
+    }
+    canvas.classList.remove('hidden');
+    fetchDataset(category)
+        .then((dataset) => {
+            const records = Array.isArray(dataset?.records) ? dataset.records : [];
+            const valueFields = Array.isArray(chart.value_fields) ? chart.value_fields : [];
+            const { labels, series } = prepareChartData(records, chart.dimension_field, valueFields);
+            const hasValues = series.some((values) => values.some((value) => typeof value === 'number'));
+
+            if (!labels.length || !hasValues) {
+                if (messageEl) {
+                    messageEl.classList.remove('hidden');
+                    messageEl.textContent = 'Não há dados numéricos suficientes para renderizar este gráfico.';
+                }
+                canvas.classList.add('hidden');
+                return;
+            }
+
+            const datasets = buildDatasets({ ...chart, value_fields: valueFields }, labels, series);
+            const context = canvas.getContext('2d');
+            if (!context) return;
+
+            if (chartInstances.has(chart.id)) {
+                chartInstances.get(chart.id).destroy();
+            }
+
+            const instance = new Chart(context, {
+                type: chart.chart_type || 'bar',
+                data: {
+                    labels,
+                    datasets
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: {
+                            position: 'bottom',
+                            labels: {
+                                color: 'rgba(226, 232, 240, 0.85)',
+                                padding: 14,
+                                usePointStyle: true
+                            }
+                        },
+                        tooltip: {
+                            mode: 'index',
+                            intersect: false
+                        }
+                    },
+                    scales: chart.chart_type === 'pie' || chart.chart_type === 'doughnut'
+                        ? {}
+                        : {
+                            x: {
+                                ticks: {
+                                    color: 'rgba(226, 232, 240, 0.7)'
+                                },
+                                grid: {
+                                    color: 'rgba(148, 163, 184, 0.15)'
+                                }
+                            },
+                            y: {
+                                ticks: {
+                                    color: 'rgba(226, 232, 240, 0.7)'
+                                },
+                                grid: {
+                                    color: 'rgba(148, 163, 184, 0.15)'
+                                }
+                            }
+                        }
+                }
+            });
+            chartInstances.set(chart.id, instance);
+        })
+        .catch((error) => {
+            if (messageEl) {
+                messageEl.classList.remove('hidden');
+                messageEl.textContent = error.message || 'Falha ao carregar dados do gráfico.';
+            }
+            canvas.classList.add('hidden');
+        });
+}
+
+function createChartCard(chart) {
+    const card = document.createElement('div');
+    const modalClass = ctx.themeClasses?.modal || '';
+    card.className = `glass-panel ${modalClass} border border-white/5 rounded-3xl p-5 space-y-4`;
+
+    const header = document.createElement('div');
+    header.className = 'flex items-start justify-between gap-3';
+
+    const info = document.createElement('div');
+    info.className = 'space-y-1';
+
+    const title = document.createElement('h3');
+    title.className = 'text-lg font-semibold';
+    title.textContent = chart.nome || `${slugToLabel(chart.chart_type)} - ${slugToLabel(chart.categoria)}`;
+
+    const meta = document.createElement('p');
+    meta.className = 'text-xs text-white/50 uppercase tracking-widest';
+    meta.textContent = `${slugToLabel(chart.categoria)} • ${slugToLabel(chart.chart_type)}`;
+
+    info.appendChild(title);
+    info.appendChild(meta);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'p-2 rounded-full border border-transparent text-white/60 hover:text-rose-400 hover:border-rose-400 transition-colors';
+    deleteBtn.innerHTML = `
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+    `;
+    deleteBtn.addEventListener('click', () => openDeleteModal(chart));
+
+    header.appendChild(info);
+    header.appendChild(deleteBtn);
+
+    const canvasWrapper = document.createElement('div');
+    canvasWrapper.className = 'relative rounded-3xl border border-white/10 bg-white/5 h-[320px] overflow-hidden';
+
+    const canvas = document.createElement('canvas');
+    canvasWrapper.appendChild(canvas);
+
+    const message = document.createElement('div');
+    message.className = 'hidden absolute inset-0 flex items-center justify-center px-6 text-center text-sm text-white/60';
+    canvasWrapper.appendChild(message);
+
+    const details = document.createElement('p');
+    details.className = 'text-xs text-white/50 uppercase tracking-widest';
+    const valueFields = Array.isArray(chart.value_fields) ? chart.value_fields : [];
+    details.textContent = `Eixo: ${chart.dimension_field} • Valores: ${valueFields.length ? valueFields.join(', ') : '-'}`;
+
+    card.appendChild(header);
+    card.appendChild(canvasWrapper);
+    card.appendChild(details);
+
+    renderChartInstance(chart, canvas, message);
+
+    return card;
+}
+
+function destroyAllCharts() {
+    chartInstances.forEach((instance) => {
+        if (instance && typeof instance.destroy === 'function') {
+            instance.destroy();
+        }
+    });
+    chartInstances.clear();
+}
+
+function renderCharts() {
+    if (!elements.chartsGrid) return;
+    destroyAllCharts();
+    elements.chartsGrid.innerHTML = '';
+    if (!state.charts.length) {
+        if (elements.chartsEmptyState) {
+            elements.chartsEmptyState.classList.remove('hidden');
+        }
+        if (elements.chartsSubtitle) {
+            elements.chartsSubtitle.textContent = 'Crie seu primeiro gráfico para compartilhar insights das categorias da Análise JP.';
+        }
+        return;
+    }
+
+    if (elements.chartsEmptyState) {
+        elements.chartsEmptyState.classList.add('hidden');
+    }
+    if (elements.chartsSubtitle) {
+        elements.chartsSubtitle.textContent = 'Explore as visualizações salvas para este workflow.';
+    }
+
+    state.charts.forEach((chart) => {
+        const card = createChartCard(chart);
+        elements.chartsGrid.appendChild(card);
+    });
+}
+
+async function refreshCharts() {
+    const url = ctx.endpoints?.list;
+    if (!url) return;
+    try {
+        const response = await fetch(url);
+        const data = await response.json().catch(() => []);
+        if (!response.ok) {
+            throw new Error(data?.error || 'Não foi possível atualizar os gráficos.');
+        }
+        state.charts = Array.isArray(data) ? data : [];
+        renderCharts();
+        showToast('Galeria atualizada com sucesso.');
+    } catch (error) {
+        showToast(error.message || 'Falha ao atualizar gráficos.', 'error');
+    }
+}
+
+function buildCreatePayload() {
+    const categoria = elements.chartCategory?.value;
+    const chartType = elements.chartType?.value;
+    const dimension = elements.dimensionField?.value;
+    const values = getSelectedValueFields();
+    const nome = elements.chartTitle?.value?.trim();
+
+    const payload = {
+        categoria,
+        chart_type: chartType,
+        dimension_field: dimension,
+        value_fields: values
+    };
+    if (nome) {
+        payload.nome = nome;
+    }
+    return payload;
+}
+
+async function submitChart(event) {
+    event.preventDefault();
+    const payload = buildCreatePayload();
+
+    if (!payload.categoria) {
+        setFormFeedback('Selecione uma categoria com dados disponíveis.');
+        return;
+    }
+    if (!payload.dimension_field) {
+        setFormFeedback('Escolha um campo para o eixo principal.');
+        return;
+    }
+    if (!payload.value_fields || !payload.value_fields.length) {
+        setFormFeedback('Selecione ao menos um campo de valor.');
+        return;
+    }
+
+    const url = ctx.endpoints?.create;
+    if (!url) return;
+
+    setFormFeedback('');
+    setSubmitLoading(true);
+
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload)
+        });
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) {
+            throw new Error(data?.error || 'Não foi possível criar o gráfico.');
+        }
+        if (data?.grafico) {
+            state.charts.unshift(data.grafico);
+            renderCharts();
+            showToast('Gráfico criado com sucesso.');
+            closeModal();
+        }
+    } catch (error) {
+        setFormFeedback(error.message || 'Falha ao criar o gráfico.');
+    } finally {
+        setSubmitLoading(false);
+    }
+}
+
+async function confirmDelete() {
+    if (!state.pendingDelete) return;
+    const url = buildDeleteUrl(state.pendingDelete);
+    if (!url) return;
+
+    setDeleteLoading(true);
+    try {
+        const response = await fetch(url, { method: 'DELETE' });
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) {
+            throw new Error(data?.error || 'Não foi possível remover o gráfico.');
+        }
+        state.charts = state.charts.filter((chart) => chart.id !== state.pendingDelete);
+        chartInstances.get(state.pendingDelete)?.destroy();
+        chartInstances.delete(state.pendingDelete);
+        renderCharts();
+        showToast('Gráfico removido com sucesso.');
+        closeDeleteModal();
+    } catch (error) {
+        showToast(error.message || 'Falha ao remover o gráfico.', 'error');
+        setDeleteLoading(false);
+    }
+}
+
+function handleGlobalClick(event) {
+    if (event.target === elements.chartModalOverlay) {
+        closeModal();
+    }
+    if (event.target === elements.deleteModalOverlay) {
+        closeDeleteModal();
+    }
+}
+
+function initEvents() {
+    if (elements.openModalBtn) {
+        elements.openModalBtn.addEventListener('click', openModal);
+    }
+    if (elements.emptyStateCreateBtn) {
+        elements.emptyStateCreateBtn.addEventListener('click', openModal);
+    }
+    if (elements.closeModalBtn) {
+        elements.closeModalBtn.addEventListener('click', closeModal);
+    }
+    if (elements.cancelModalBtn) {
+        elements.cancelModalBtn.addEventListener('click', closeModal);
+    }
+    if (elements.chartCategory) {
+        elements.chartCategory.addEventListener('change', (event) => {
+            const value = event.target.value;
+            updateCategoryHint(value);
+            loadFieldsForCategory(value);
+        });
+    }
+    if (elements.toggleSelectAllValues) {
+        elements.toggleSelectAllValues.addEventListener('click', toggleSelectAllValues);
+    }
+    if (elements.chartForm) {
+        elements.chartForm.addEventListener('submit', submitChart);
+    }
+    if (elements.refreshBtn) {
+        elements.refreshBtn.addEventListener('click', refreshCharts);
+    }
+    if (elements.chartModalOverlay) {
+        elements.chartModalOverlay.addEventListener('click', closeModal);
+    }
+    if (elements.deleteModalOverlay) {
+        elements.deleteModalOverlay.addEventListener('click', closeDeleteModal);
+    }
+    if (elements.cancelDeleteBtn) {
+        elements.cancelDeleteBtn.addEventListener('click', closeDeleteModal);
+    }
+    if (elements.closeDeleteModalBtn) {
+        elements.closeDeleteModalBtn.addEventListener('click', closeDeleteModal);
+    }
+    if (elements.confirmDeleteBtn) {
+        elements.confirmDeleteBtn.addEventListener('click', confirmDelete);
+    }
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+            if (!elements.chartModal?.classList.contains('hidden')) {
+                closeModal();
+            }
+            if (!elements.deleteModal?.classList.contains('hidden')) {
+                closeDeleteModal();
+            }
+        }
+    });
+    document.addEventListener('click', handleGlobalClick);
+}
+
+function init() {
+    renderCharts();
+    initEvents();
+}
+
+init();

--- a/app/templates/analise_jp.html
+++ b/app/templates/analise_jp.html
@@ -119,6 +119,9 @@
                                     <button id="refreshButton" class="hidden {{ theme.buttons.secondary }} px-4 py-2.5 rounded-full text-sm uppercase tracking-wide transition-transform duration-300 hover:-translate-y-0.5">
                                         Atualizar lista
                                     </button>
+                                    <button id="chartsButton" class="{{ theme.buttons.secondary }} px-5 py-2.5 rounded-full text-sm uppercase tracking-wide transition-transform duration-300 hover:-translate-y-0.5">
+                                        Área de gráficos
+                                    </button>
                                     <button id="uploadButton" class="{{ theme.buttons.primary }} px-5 py-2.5 rounded-full text-sm uppercase tracking-wide flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed">
                                         <span>Enviar arquivo</span>
                                         <span id="uploadSpinner" class="hidden w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"></span>
@@ -211,6 +214,7 @@
     <script>
         const workflowId = {{ workflow.id }};
         const categories = {{ categories | tojson }};
+        const chartsViewUrl = "{{ url_for('analise_jp.analise_jp_charts_view', workflow_id=workflow.id) }}";
         let currentCategory = categories.length ? categories[0] : null;
         let uploadsCache = {};
         let activeUploadId = null;
@@ -234,6 +238,7 @@
         const tableBody = document.getElementById('tableBody');
         const activeUploadInfo = document.getElementById('activeUploadInfo');
         const refreshButton = document.getElementById('refreshButton');
+        const chartsButton = document.getElementById('chartsButton');
         const deleteModal = document.getElementById('deleteModal');
         const deleteModalMessage = document.getElementById('deleteModalMessage');
         const deleteModalOverlay = document.getElementById('deleteModalOverlay');
@@ -651,17 +656,25 @@
                 });
             }
 
+            if (chartsButton && chartsViewUrl) {
+                chartsButton.addEventListener('click', () => {
+                    window.location.href = chartsViewUrl;
+                });
+            }
+
             fileInput.addEventListener('change', () => {
                 if (fileInput.files && fileInput.files[0]) {
                     uploadFileForCategory();
                 }
             });
 
-            refreshButton.addEventListener('click', () => {
-                if (currentCategory) {
-                    loadUploads(currentCategory);
-                }
-            });
+            if (refreshButton) {
+                refreshButton.addEventListener('click', () => {
+                    if (currentCategory) {
+                        loadUploads(currentCategory);
+                    }
+                });
+            }
         }
 
         function logout() {

--- a/app/templates/analise_jp_charts.html
+++ b/app/templates/analise_jp_charts.html
@@ -3,56 +3,244 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Gerar Gráficos - {{ workflow.nome }}</title>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-</head>
-<body>
-    <h1>Gerar Gráficos para {{ workflow.nome }}</h1>
-    <form id="chartForm">
-        <label for="category">Selecione a Categoria:</label>
-        <select id="category" name="category">
-            {% for category in categories %}
-                <option value="{{ category }}">{{ category }}</option>
-            {% endfor %}
-        </select>
-
-        <label for="chartType">Selecione o Tipo de Gráfico:</label>
-        <select id="chartType" name="chartType">
-            <option value="bar">Barra</option>
-            <option value="line">Linha</option>
-            <option value="pie">Pizza</option>
-        </select>
-
-        <button type="button" onclick="generateChart()">Gerar Gráfico</button>
-    </form>
-
-    <canvas id="chartCanvas"></canvas>
-
+    <title>{{ workflow.nome }} - Área de gráficos</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
     <script>
-        function generateChart() {
-            const category = document.getElementById('category').value;
-            const chartType = document.getElementById('chartType').value;
-
-            // Simulação de dados - Substituir com dados reais da categoria
-            const data = {
-                labels: ['Janeiro', 'Fevereiro', 'Março'],
-                datasets: [{
-                    label: category,
-                    data: [10, 20, 30],
-                    backgroundColor: ['red', 'blue', 'green']
-                }]
-            };
-
-            const config = {
-                type: chartType,
-                data: data
-            };
-
-            new Chart(
-                document.getElementById('chartCanvas'),
-                config
-            );
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Space Grotesk', 'Segoe UI', '-apple-system', 'system-ui', 'sans-serif']
+                    }
+                }
+            }
         }
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+    <style>
+        :root {
+            --glass-border: rgba(255, 255, 255, 0.08);
+            --glass-bg: rgba(15, 23, 42, 0.65);
+        }
+
+        .glass-panel {
+            backdrop-filter: blur(24px);
+            -webkit-backdrop-filter: blur(24px);
+        }
+
+        .scale-in {
+            animation: scaleIn 0.35s ease forwards;
+        }
+
+        @keyframes scaleIn {
+            0% {
+                opacity: 0;
+                transform: scale(0.94);
+            }
+            100% {
+                opacity: 1;
+                transform: scale(1);
+            }
+        }
+    </style>
+</head>
+<body class="{{ theme.bg }} {{ theme.text }} font-sans h-screen overflow-hidden">
+    <div class="flex h-full">
+        {% include 'partials/sidebar.html' %}
+
+        <main class="flex-1 h-full overflow-y-auto">
+            <div class="max-w-7xl mx-auto px-6 md:px-10 py-10 space-y-8">
+                <header class="glass-panel {{ theme.modal }} border border-white/5 rounded-3xl p-8 shadow-2xl shadow-emerald-500/10">
+                    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
+                        <div class="space-y-4">
+                            <div class="flex items-center gap-4">
+                                <a href="{{ url_for('analise_jp.analise_jp_view', workflow_id=workflow.id) }}" class="inline-flex items-center justify-center w-10 h-10 rounded-full border border-white/10 hover:border-white/30 transition-colors duration-300" title="Voltar para uploads">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+                                    </svg>
+                                </a>
+                                <div>
+                                    <p class="text-sm uppercase tracking-[0.35em] text-white/50">Workflow</p>
+                                    <h1 class="text-3xl md:text-4xl font-semibold tracking-tight">{{ workflow.nome }}</h1>
+                                </div>
+                                <span class="px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wide {{ theme.badge['analise_jp'] }}">
+                                    Área de gráficos
+                                </span>
+                            </div>
+                            <p class="text-white/70 max-w-3xl leading-relaxed">
+                                Transforme os uploads das categorias da Análise JP em visualizações interativas.
+                            </p>
+                            <p class="text-xs text-white/40 uppercase tracking-widest">
+                                Atualizado em {{ workflow.data_criacao.strftime('%d/%m/%Y %H:%M') }}
+                            </p>
+                        </div>
+
+                        <div class="flex flex-col sm:flex-row gap-4">
+                            <button id="openCreateChartBtn" class="{{ theme.buttons.primary }} px-6 py-2.5 rounded-full text-sm font-semibold tracking-wide uppercase shadow-lg shadow-emerald-500/20 transition-transform duration-300 hover:-translate-y-0.5">
+                                Criar gráfico
+                            </button>
+                            <button id="refreshChartsBtn" class="{{ theme.buttons.secondary }} px-6 py-2.5 rounded-full text-sm font-semibold tracking-wide uppercase transition-transform duration-300 hover:-translate-y-0.5">
+                                Atualizar
+                            </button>
+                        </div>
+                    </div>
+                </header>
+
+                <section class="space-y-6">
+                    <div class="glass-panel {{ theme.modal }} border border-white/5 rounded-3xl p-6 md:p-7 shadow-xl shadow-emerald-500/10">
+                        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-6">
+                            <div class="space-y-2">
+                                <h2 class="text-2xl font-semibold tracking-tight">Galeria de gráficos</h2>
+                                <p id="chartsSubtitle" class="text-sm text-white/60">
+                                    {% if charts %}
+                                        Explore as visualizações salvas para este workflow.
+                                    {% else %}
+                                        Crie seu primeiro gráfico para compartilhar insights das categorias da Análise JP.
+                                    {% endif %}
+                                </p>
+                            </div>
+                        </div>
+
+                        <div id="chartsEmptyState" class="{% if charts %}hidden{% endif %} border border-dashed border-white/10 rounded-2xl p-10 text-center space-y-4">
+                            <div class="w-12 h-12 mx-auto rounded-full border border-white/15 flex items-center justify-center text-white/50">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m6-6H6" />
+                                </svg>
+                            </div>
+                            <h3 class="text-lg font-semibold">Nenhum gráfico criado ainda</h3>
+                            <p class="text-sm text-white/60 max-w-xl mx-auto">Utilize o botão "Criar gráfico" para escolher uma categoria, selecionar os campos e montar visualizações personalizadas.</p>
+                            <button id="emptyStateCreateBtn" class="{{ theme.buttons.primary }} px-5 py-2.5 rounded-full text-sm uppercase tracking-wide">Criar gráfico agora</button>
+                        </div>
+
+                        <div id="chartsGrid" class="grid grid-cols-1 md:grid-cols-2 gap-6"></div>
+                    </div>
+                </section>
+            </div>
+        </main>
+    </div>
+
+    <div id="toastContainer" class="fixed bottom-6 right-6 z-[80] space-y-3"></div>
+
+    <div id="chartModal" class="fixed inset-0 hidden z-[90] items-center justify-center">
+        <div id="chartModalOverlay" class="absolute inset-0 bg-slate-950/70 backdrop-blur-xl"></div>
+        <div class="relative w-full max-w-2xl mx-auto glass-panel {{ theme.modal }} border border-white/10 rounded-3xl p-8 space-y-6 scale-in">
+            <div class="flex items-start justify-between gap-4">
+                <div>
+                    <h2 class="text-2xl font-semibold tracking-tight">Configurar gráfico</h2>
+                    <p class="text-sm text-white/60 mt-2">Selecione a categoria, os campos que deseja visualizar e o tipo de gráfico.</p>
+                </div>
+                <button id="closeChartModalBtn" class="w-10 h-10 rounded-full border border-white/10 hover:border-white/30 flex items-center justify-center transition-colors" title="Fechar">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.6">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+
+            <form id="chartForm" class="space-y-6">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div class="flex flex-col gap-2">
+                        <label for="chartTitle" class="text-xs uppercase tracking-widest text-white/50">Título do gráfico (opcional)</label>
+                        <input id="chartTitle" type="text" class="rounded-2xl px-4 py-3 bg-white/5 border border-white/10 focus:outline-none focus:ring-2 focus:ring-emerald-500/60" placeholder="Ex: Evolução da categoria">
+                    </div>
+                    <div class="flex flex-col gap-2">
+                        <label for="chartType" class="text-xs uppercase tracking-widest text-white/50">Tipo de gráfico</label>
+                        <select id="chartType" class="rounded-2xl px-4 py-3 bg-white/5 border border-white/10 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500/60"></select>
+                    </div>
+                </div>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div class="flex flex-col gap-2">
+                        <label for="chartCategory" class="text-xs uppercase tracking-widest text-white/50">Categoria</label>
+                        <select id="chartCategory" class="rounded-2xl px-4 py-3 bg-white/5 border border-white/10 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500/60"></select>
+                        <p id="categoryHint" class="text-xs text-white/40"></p>
+                    </div>
+                    <div class="flex flex-col gap-2">
+                        <label for="dimensionField" class="text-xs uppercase tracking-widest text-white/50">Campo para o eixo</label>
+                        <select id="dimensionField" class="rounded-2xl px-4 py-3 bg-white/5 border border-white/10 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500/60" disabled>
+                            <option value="">Selecione uma categoria</option>
+                        </select>
+                    </div>
+                </div>
+
+                <div class="space-y-3">
+                    <div class="flex items-center justify-between">
+                        <span class="text-xs uppercase tracking-widest text-white/50">Campos de valores</span>
+                        <button type="button" id="toggleSelectAllValues" class="text-xs uppercase tracking-widest text-emerald-300 hover:text-emerald-200 hidden">Selecionar todos</button>
+                    </div>
+                    <div id="fieldLoadingState" class="hidden text-sm text-white/60">Carregando campos disponíveis...</div>
+                    <div id="valueFieldEmpty" class="hidden text-sm text-white/60">Nenhum campo disponível para a categoria escolhida.</div>
+                    <div id="valueFieldOptions" class="grid grid-cols-1 md:grid-cols-2 gap-2 max-h-48 overflow-y-auto pr-1"></div>
+                </div>
+
+                <p id="chartFormFeedback" class="hidden text-sm text-rose-300 bg-rose-500/10 border border-rose-500/30 rounded-2xl px-4 py-3"></p>
+
+                <div class="flex flex-col-reverse sm:flex-row sm:justify-end gap-3">
+                    <button type="button" id="cancelChartBtn" class="w-full sm:w-auto {{ theme.buttons.secondary }} px-5 py-2.5 rounded-full text-sm uppercase tracking-wide">Cancelar</button>
+                    <button type="submit" id="submitChartBtn" class="w-full sm:w-auto {{ theme.buttons.primary }} px-5 py-2.5 rounded-full text-sm uppercase tracking-wide flex items-center justify-center gap-2">
+                        <span>Criar gráfico</span>
+                        <span id="submitChartSpinner" class="hidden w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"></span>
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div id="deleteModal" class="fixed inset-0 hidden z-[95] items-center justify-center">
+        <div id="deleteModalOverlay" class="absolute inset-0 bg-slate-950/70 backdrop-blur-xl"></div>
+        <div class="relative w-full max-w-md mx-auto glass-panel {{ theme.modal }} border border-white/10 rounded-3xl p-7 space-y-5 scale-in">
+            <div class="flex items-start gap-4">
+                <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-rose-500/10 text-rose-400">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v4m0 4h.01M4.5 19.5l7.5-15 7.5 15h-15z" />
+                    </svg>
+                </div>
+                <div class="flex-1 space-y-2">
+                    <h3 class="text-xl font-semibold tracking-tight">Excluir gráfico</h3>
+                    <p id="deleteModalMessage" class="text-sm text-white/60">Tem certeza que deseja remover este gráfico?</p>
+                </div>
+                <button id="closeDeleteModalBtn" class="w-10 h-10 rounded-full border border-white/10 hover:border-white/30 flex items-center justify-center transition-colors" title="Fechar">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.6">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+            <div class="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-white/60">
+                A exclusão remove apenas o gráfico salvo. Os uploads e dados originais permanecerão disponíveis.
+            </div>
+            <div class="flex flex-col-reverse sm:flex-row sm:justify-end gap-3">
+                <button id="cancelDeleteBtn" class="w-full sm:w-auto {{ theme.buttons.secondary }} px-5 py-2.5 rounded-full text-sm uppercase tracking-wide">Cancelar</button>
+                <button id="confirmDeleteBtn" class="w-full sm:w-auto px-5 py-2.5 rounded-full text-sm uppercase tracking-wide bg-rose-500/90 hover:bg-rose-500 text-white flex items-center justify-center gap-2">
+                    <span>Excluir gráfico</span>
+                    <span id="deleteSpinner" class="hidden w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"></span>
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        window.__ANALISE_JP__ = {
+            workflowId: {{ workflow.id }},
+            workflowName: {{ workflow.nome | tojson }},
+            charts: {{ charts | tojson | safe }},
+            categories: {{ categories_meta | tojson | safe }},
+            allowedChartTypes: {{ allowed_chart_types | tojson | safe }},
+            themePalette: {{ theme.chart_palette | tojson | safe }},
+            endpoints: {
+                list: "{{ url_for('analise_jp.listar_graficos_analise_jp', workflow_id=workflow.id) }}",
+                create: "{{ url_for('analise_jp.criar_grafico_analise_jp', workflow_id=workflow.id) }}",
+                delete: "{{ url_for('analise_jp.excluir_grafico_analise_jp', workflow_id=workflow.id, grafico_id=0) }}",
+                dataset: "{{ url_for('analise_jp.obter_dataset_categoria', workflow_id=workflow.id, categoria='__categoria__') }}"
+            },
+            themeClasses: {
+                toastSuccess: '{{ theme.toast.success }}',
+                toastError: '{{ theme.toast.error }}',
+                modal: '{{ theme.modal }}'
+            }
+        };
+    </script>
+    <script type="module" src="{{ url_for('static', filename='js/analise_jp_charts.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- introduce an AnaliseJPChart model and backend endpoints to manage gráficos for workflows do tipo Análise JP
- add a dedicated Área de Gráficos page with Tailwind UI and Chart.js integration for selecting categorias, campos e tipos de gráfico
- expose navigation from the upload dashboard and create rich front-end logic to fetch datasets, render gráficos e controlar exclusões

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_b_68dd1ce987508321af67326857c3d342