### PR TITLE
Highlight upload state for Análise JP categories

### DIFF
--- a/app/templates/analise_jp.html
+++ b/app/templates/analise_jp.html
@@ -59,6 +59,33 @@
                 transform: scale(1);
             }
         }
+
+        .category-button {
+            border-width: 1px;
+            border-style: solid;
+            border-color: rgba(248, 113, 113, 0.55);
+            background-color: rgba(255, 255, 255, 0.03);
+            color: rgba(255, 255, 255, 0.75);
+            transition: border-color 0.3s ease, background-color 0.3s ease, color 0.3s ease, transform 0.3s ease;
+        }
+
+        .category-button:hover {
+            border-color: rgba(94, 234, 212, 0.6);
+        }
+
+        .category-button.no-upload {
+            border-color: rgba(248, 113, 113, 0.65);
+        }
+
+        .category-button.has-upload {
+            border-color: rgba(52, 211, 153, 0.65);
+        }
+
+        .category-button.is-active {
+            border-color: rgba(16, 185, 129, 0.85);
+            background-color: rgba(16, 185, 129, 0.12);
+            color: #fff;
+        }
     </style>
 </head>
 <body class="{{ theme.bg }} {{ theme.text }} font-sans h-screen overflow-hidden">
@@ -197,12 +224,21 @@
         const tableBody = document.getElementById('tableBody');
         const activeUploadInfo = document.getElementById('activeUploadInfo');
         const refreshButton = document.getElementById('refreshButton');
+        const categoryButtons = new Map();
+        const categoryUploadStatus = {};
 
         function slugToLabel(slug) {
             return slug
                 .split('_')
                 .map(word => word ? word.charAt(0).toUpperCase() + word.slice(1) : '')
                 .join(' ');
+        }
+
+        function hasRealUploads(uploads) {
+            if (!Array.isArray(uploads)) {
+                return false;
+            }
+            return uploads.some(upload => !upload.is_template);
         }
 
         function showToast(message, type = 'success') {
@@ -334,18 +370,44 @@
             });
         }
 
+        function updateCategoryStatusIndicators() {
+            categoryButtons.forEach((button, category) => {
+                button.classList.remove('has-upload', 'no-upload');
+                const cachedUploads = uploadsCache[category];
+                const hasUploads = categoryUploadStatus.hasOwnProperty(category)
+                    ? categoryUploadStatus[category]
+                    : hasRealUploads(cachedUploads);
+                button.classList.add(hasUploads ? 'has-upload' : 'no-upload');
+            });
+        }
+
+        function highlightActiveCategoryButton() {
+            categoryButtons.forEach((button, category) => {
+                if (category === currentCategory) {
+                    button.classList.add('is-active');
+                } else {
+                    button.classList.remove('is-active');
+                }
+            });
+        }
+
         function renderUploads(category, uploads) {
             uploadsList.innerHTML = '';
 
-            if (!uploads.length) {
+            const normalizedUploads = Array.isArray(uploads) ? uploads : [];
+            categoryUploadStatus[category] = hasRealUploads(normalizedUploads);
+
+            if (!normalizedUploads.length) {
                 uploadsEmptyState.classList.remove('hidden');
                 clearTable();
+                updateCategoryStatusIndicators();
+                highlightActiveCategoryButton();
                 return;
             }
 
             uploadsEmptyState.classList.add('hidden');
 
-            uploads.forEach((upload, index) => {
+            normalizedUploads.forEach((upload, index) => {
                 const button = document.createElement('button');
                 button.type = 'button';
                 const uploadId = normalizeUploadId(upload.id);
@@ -371,27 +433,22 @@
 
                 uploadsList.appendChild(button);
 
-                if (index === 0 && (activeUploadId === null || !uploads.some(item => normalizeUploadId(item.id) === activeUploadId))) {
+                if (index === 0 && (activeUploadId === null || !normalizedUploads.some(item => normalizeUploadId(item.id) === activeUploadId))) {
                     activeUploadId = uploadId;
                     renderTable(upload.dados_extraidos, upload);
                 }
             });
 
             highlightActiveUpload(activeUploadId);
+            updateCategoryStatusIndicators();
+            highlightActiveCategoryButton();
         }
 
         function setActiveCategory(category) {
             currentCategory = category;
             activeUploadId = null;
             updateCategoryHeader();
-
-            Array.from(categoryList.querySelectorAll('button[data-category]')).forEach(button => {
-                if (button.dataset.category === category) {
-                    button.classList.add('border-emerald-400', 'bg-emerald-500/10', 'text-white');
-                } else {
-                    button.classList.remove('border-emerald-400', 'bg-emerald-500/10', 'text-white');
-                }
-            });
+            highlightActiveCategoryButton();
 
             if (!category) {
                 uploadsList.innerHTML = '';
@@ -418,11 +475,15 @@
                 const button = document.createElement('button');
                 button.type = 'button';
                 button.dataset.category = category;
-                button.className = 'w-full text-left px-4 py-2.5 rounded-2xl border border-white/10 bg-white/5 hover:border-emerald-400 transition-colors duration-300';
+                button.className = 'category-button w-full text-left px-4 py-2.5 rounded-2xl border bg-white/5 transition-colors duration-300';
+                button.classList.add('no-upload');
                 button.textContent = slugToLabel(category);
                 button.addEventListener('click', () => setActiveCategory(category));
                 categoryList.appendChild(button);
+                categoryButtons.set(category, button);
             });
+
+            updateCategoryStatusIndicators();
         }
 
         function loadUploads(category) {
@@ -452,6 +513,43 @@
                 })
                 .finally(() => {
                     setLoadingUploads(false);
+                });
+        }
+
+        function loadInitialCategoryStatus() {
+            if (!categories.length) {
+                updateCategoryHeader();
+                return;
+            }
+
+            fetch(`/analise_jp/${workflowId}/upload-status`)
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error('Request failed');
+                    }
+                    return response.json();
+                })
+                .then(data => {
+                    if (data.error) {
+                        showToast(data.error, 'error');
+                        return;
+                    }
+                    if (data && data.status) {
+                        Object.entries(data.status).forEach(([category, hasUpload]) => {
+                            categoryUploadStatus[category] = Boolean(hasUpload);
+                        });
+                    }
+                })
+                .catch(() => {
+                    showToast('Não foi possível carregar o status dos uploads.', 'error');
+                })
+                .finally(() => {
+                    updateCategoryStatusIndicators();
+                    if (currentCategory) {
+                        setActiveCategory(currentCategory);
+                    } else {
+                        updateCategoryHeader();
+                    }
                 });
         }
 
@@ -487,8 +585,8 @@
                     fileInput.value = '';
                     const existingUploads = (uploadsCache[currentCategory] || []).filter(item => !item.is_template);
                     uploadsCache[currentCategory] = [data.upload, ...existingUploads];
+                    categoryUploadStatus[currentCategory] = true;
                     renderUploads(currentCategory, uploadsCache[currentCategory]);
-                    highlightActiveCategoryButton();
                 })
                 .catch(() => {
                     showToast('Falha ao enviar o arquivo.', 'error');
@@ -496,16 +594,6 @@
                 .finally(() => {
                     setUploadingState(false);
                 });
-        }
-
-        function highlightActiveCategoryButton() {
-            Array.from(categoryList.querySelectorAll('button[data-category]')).forEach(button => {
-                if (button.dataset.category === currentCategory) {
-                    button.classList.add('border-emerald-400', 'bg-emerald-500/10', 'text-white');
-                } else {
-                    button.classList.remove('border-emerald-400', 'bg-emerald-500/10', 'text-white');
-                }
-            });
         }
 
         function initEvents() {
@@ -655,11 +743,7 @@
             createCategoryButtons();
             initEvents();
             createThemeMenu();
-            if (currentCategory) {
-                setActiveCategory(currentCategory);
-            } else {
-                updateCategoryHeader();
-            }
+            loadInitialCategoryStatus();
 
             document.addEventListener('click', function(event) {
                 const menu = document.getElementById('themeMenu');


### PR DESCRIPTION
## Summary
- add an endpoint that reports whether each Análise JP category already has uploads saved
- update the Análise JP dashboard to style categories with green or red borders based on upload status
- refresh category indicators after fetching data and completing new uploads

## Testing
- not run (existing syntax error in app/models/analise_upload.py blocks app startup)


------
https://chatgpt.com/codex/tasks/task_b_68dd2659d2108321aba590e242f948e5