### PR TITLE
Handle time strings in parseNumeric

### DIFF
--- a/app/static/js/analise_jp_charts.js
+++ b/app/static/js/analise_jp_charts.js
@@ -399,6 +399,15 @@ function parseNumeric(value) {
     if (typeof value !== 'string') return null;
     const trimmed = value.trim();
     if (!trimmed) return null;
+    const timeMatch = trimmed.match(/^([+-]?)(\d+):([0-5]?\d)(?::([0-5]?\d))?$/);
+    if (timeMatch) {
+        const sign = timeMatch[1] === '-' ? -1 : 1;
+        const hours = parseInt(timeMatch[2], 10);
+        const minutes = parseInt(timeMatch[3], 10);
+        const seconds = timeMatch[4] ? parseInt(timeMatch[4], 10) : 0;
+        const decimalHours = hours + minutes / 60 + seconds / 3600;
+        return sign * decimalHours;
+    }
     let normalized = trimmed.replace(/\s+/g, '');
     if (normalized.includes(',') && normalized.includes('.')) {
         normalized = normalized.replace(/\./g, '').replace(',', '.');


### PR DESCRIPTION
## Summary
- detect signed HH:MM(:SS) strings when parsing chart values
- convert matched durations into decimal hours while keeping other numeric parsing intact

## Testing
- not run (manual verification requires the full frontend environment)


------
https://chatgpt.com/codex/tasks/task_b_68dd59e09ef0832183c5ac911dd3a6b6