### PR TITLE
Add chart viewing modal and adjust gallery layout

### DIFF
--- a/app/templates/analise_jp_charts.html
+++ b/app/templates/analise_jp_charts.html
@@ -115,7 +115,7 @@
                             <button id="emptyStateCreateBtn" class="{{ theme.buttons.primary }} px-5 py-2.5 rounded-full text-sm uppercase tracking-wide">Criar gráfico agora</button>
                         </div>
 
-                        <div id="chartsGrid" class="grid grid-cols-1 md:grid-cols-2 gap-6"></div>
+                        <div id="chartsGrid" class="grid grid-cols-1 gap-6"></div>
                     </div>
                 </section>
             </div>
@@ -185,6 +185,30 @@
                     </button>
                 </div>
             </form>
+        </div>
+    </div>
+
+    <div id="viewChartModal" class="fixed inset-0 hidden z-[100] px-4 flex items-center justify-center">
+        <div id="viewChartModalOverlay" class="absolute inset-0 bg-slate-950/80 backdrop-blur-2xl"></div>
+        <div class="relative w-full max-w-6xl h-[85vh] mx-auto glass-panel {{ theme.modal }} border border-white/10 rounded-3xl p-8 md:p-10 flex flex-col gap-6 scale-in">
+            <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+                <div class="space-y-2">
+                    <p id="viewChartMeta" class="text-xs text-white/50 uppercase tracking-[0.35em]"></p>
+                    <h2 id="viewChartTitle" class="text-3xl font-semibold tracking-tight"></h2>
+                </div>
+                <div class="flex items-center gap-3 self-end md:self-start">
+                    <button id="nextViewChartBtn" class="{{ theme.buttons.secondary }} px-5 py-2.5 rounded-full text-sm uppercase tracking-wide transition-transform duration-300 hover:-translate-y-0.5">Próximo</button>
+                    <button id="closeViewChartBtn" class="w-10 h-10 rounded-full border border-white/10 hover:border-white/30 flex items-center justify-center transition-colors" title="Fechar visualização">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
+            </div>
+            <div class="relative flex-1 rounded-3xl border border-white/10 bg-white/5 overflow-hidden">
+                <canvas id="viewChartCanvas" class="w-full h-full"></canvas>
+                <div id="viewChartMessage" class="hidden absolute inset-0 flex items-center justify-center px-6 text-center text-sm text-white/60"></div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- make the gallery display a single chart per row with taller canvases for better readability
- add an eye icon button that opens a nearly full-screen modal for viewing and paging through charts
- refactor chart rendering helpers so the modal reuses existing datasets without affecting the inline gallery

## Testing
- not run (UI changes require the full frontend environment)


------
https://chatgpt.com/codex/tasks/task_b_68dd59e09ef0832183c5ac911dd3a6b6