### PR TITLE
Avoid loading processed data in workflow view

### DIFF
--- a/app/routes/workflow.py
+++ b/app/routes/workflow.py
@@ -142,7 +142,6 @@ def workflow_view(workflow_nome):
         return redirect(url_for('analise_jp.analise_jp_view', workflow_id=workflow.id))
 
     arquivo_atual = _get_latest_file_for_workflow(workflow.id, include_payload=False)
-    arquivo_atual, processed_data = _get_processed_data_for_workflow(workflow.id)
 
     arquivo_atual_metadata = (
         _serialize_arquivo_metadata(arquivo_atual)


### PR DESCRIPTION
## Summary
- stop re-querying processed workflow data when rendering the main workflow view so the large payload is not loaded eagerly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e41755fa888321a1d83c48c27c44ac