### PR TITLE
Render analise_jp workflows from dashboard routes

### DIFF
--- a/app/routes/workflow.py
+++ b/app/routes/workflow.py
@@ -5,10 +5,8 @@ from flask import (
     Blueprint,
     current_app,
     jsonify,
-    redirect,
     render_template,
     request,
-    url_for,
 )
 from flask_login import login_required, current_user
 from sqlalchemy.orm import defer
@@ -20,6 +18,10 @@ from app.services.theme_service import get_theme_context
 from app.services.workflow_import_service import (
     ImportacaoArquivoErro,
     process_workflow_upload,
+)
+from app.routes.analise_jp import (
+    build_analise_jp_dashboard_context,
+    build_analise_jp_charts_context,
 )
 
 workflow_bp = Blueprint('workflow', __name__)
@@ -121,6 +123,9 @@ def dashboard():
 @login_required
 def workflow_charts_view(workflow_nome):
     workflow = _get_workflow_for_user_by_name(workflow_nome)
+    if workflow.tipo == 'analise_jp':
+        context = build_analise_jp_charts_context(workflow)
+        return render_template('analise_jp_charts.html', **context)
     arquivo_atual, processed_data = _get_processed_data_for_workflow(workflow.id)
 
     theme = get_theme_context()
@@ -139,10 +144,10 @@ def workflow_view(workflow_nome):
     """Exibe a pagina do workflow selecionado."""
     workflow = _get_workflow_for_user_by_name(workflow_nome)
     if workflow.tipo == 'analise_jp':
-        return redirect(url_for('analise_jp.analise_jp_view', workflow_id=workflow.id))
+        context = build_analise_jp_dashboard_context(workflow)
+        return render_template('analise_jp.html', **context)
 
     arquivo_atual = _get_latest_file_for_workflow(workflow.id, include_payload=False)
-    arquivo_atual, processed_data = _get_processed_data_for_workflow(workflow.id)
 
     arquivo_atual_metadata = (
         _serialize_arquivo_metadata(arquivo_atual)


### PR DESCRIPTION
## Summary
- stop re-querying processed workflow data when rendering the main workflow view so the large payload is not loaded eagerly
- render analise_jp workflows directly from the dashboard routes so both workflow types share consistent URLs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e41755fa888321a1d83c48c27c44ac