### PR TITLE
Redirect analise_jp routes to dashboard workflow view

### DIFF
--- a/app/routes/analise_jp.py
+++ b/app/routes/analise_jp.py
@@ -1,10 +1,10 @@
 import io
 from datetime import datetime
 from pathlib import Path
-from typing import List, Tuple, Optional, Iterable, Set
+from typing import Dict, List, Tuple, Optional, Iterable, Set
 
 import pandas as pd
-from flask import Blueprint, current_app, jsonify, redirect, render_template, request, url_for
+from flask import Blueprint, current_app, jsonify, redirect, request, url_for
 from flask_login import current_user, login_required
 from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
@@ -39,6 +39,52 @@ ALLOWED_EXTENSIONS = {'.csv', '.xlsx'}
 
 def _get_workflow_or_404(workflow_id: int) -> Workflow:
     return Workflow.query.filter_by(id=workflow_id, usuario_id=current_user.id).first_or_404()
+
+
+def build_analise_jp_dashboard_context(workflow: Workflow) -> Dict[str, object]:
+    theme = get_theme_context()
+    existing_categories = {
+        row[0]
+        for row in (
+            db.session.query(distinct(AnaliseUpload.categoria))
+            .filter_by(workflow_id=workflow.id)
+            .all()
+        )
+    }
+    category_status = {
+        categoria: categoria in existing_categories
+        for categoria in ANALISE_JP_CATEGORIES
+    }
+    return {
+        'workflow': workflow,
+        'theme': theme,
+        'categories': ANALISE_JP_CATEGORIES,
+        'category_status': category_status,
+    }
+
+
+def build_analise_jp_charts_context(workflow: Workflow) -> Dict[str, object]:
+    theme = get_theme_context()
+    categories_meta = []
+    for categoria in ANALISE_JP_CATEGORIES:
+        latest_upload = _get_latest_upload_for_category(workflow.id, categoria)
+        visible_records = _get_visible_records(latest_upload)
+        categories_meta.append({
+            'slug': categoria,
+            'label': _slug_to_label(categoria),
+            'has_data': bool(visible_records),
+            'latest_upload': None if not latest_upload else {
+                'id': latest_upload.id,
+                'nome_arquivo': latest_upload.nome_arquivo,
+                'created_at': latest_upload.created_at.isoformat() if latest_upload.created_at else None
+            }
+        })
+
+    return {
+        'workflow': workflow,
+        'theme': theme,
+        'categories_meta': categories_meta,
+    }
 
 
 def _validate_category(categoria: str) -> None:
@@ -192,60 +238,14 @@ def _extract_payload(file: FileStorage) -> Tuple[List[dict], bytes]:
 @login_required
 def analise_jp_view(workflow_id: int):
     workflow = _get_workflow_or_404(workflow_id)
-    if workflow.tipo != 'analise_jp':
-        return redirect(url_for('workflow.workflow_view', workflow_nome=workflow.nome))
-
-    theme = get_theme_context()
-    existing_categories = {
-        row[0]
-        for row in (
-            db.session.query(distinct(AnaliseUpload.categoria))
-            .filter_by(workflow_id=workflow.id)
-            .all()
-        )
-    }
-    category_status = {
-        categoria: categoria in existing_categories
-        for categoria in ANALISE_JP_CATEGORIES
-    }
-    return render_template(
-        'analise_jp.html',
-        workflow=workflow,
-        theme=theme,
-        categories=ANALISE_JP_CATEGORIES,
-        category_status=category_status,
-    )
+    return redirect(url_for('workflow.workflow_view', workflow_nome=workflow.nome), code=302)
 
 
 @analise_jp_bp.route('/analise_jp/<int:workflow_id>/graficos')
 @login_required
 def analise_jp_charts_view(workflow_id: int):
     workflow = _get_workflow_or_404(workflow_id)
-    if workflow.tipo != 'analise_jp':
-        return redirect(url_for('workflow.workflow_view', workflow_nome=workflow.nome))
-
-    theme = get_theme_context()
-
-    categories_meta = []
-    for categoria in ANALISE_JP_CATEGORIES:
-        latest_upload = _get_latest_upload_for_category(workflow.id, categoria)
-        visible_records = _get_visible_records(latest_upload)
-        categories_meta.append({
-            'slug': categoria,
-            'label': _slug_to_label(categoria),
-            'has_data': bool(visible_records),
-            'latest_upload': None if not latest_upload else {
-                'id': latest_upload.id,
-                'nome_arquivo': latest_upload.nome_arquivo,
-                'created_at': latest_upload.created_at.isoformat() if latest_upload.created_at else None
-            }
-        })
-    return render_template(
-        'analise_jp_charts.html',
-        workflow=workflow,
-        theme=theme,
-        categories_meta=categories_meta,
-    )
+    return redirect(url_for('workflow.workflow_charts_view', workflow_nome=workflow.nome), code=302)
 
 
 @analise_jp_bp.route('/analise_jp/<int:workflow_id>/uploads/<string:categoria>', methods=['GET'])

--- a/app/routes/workflow.py
+++ b/app/routes/workflow.py
@@ -5,10 +5,8 @@ from flask import (
     Blueprint,
     current_app,
     jsonify,
-    redirect,
     render_template,
     request,
-    url_for,
 )
 from flask_login import login_required, current_user
 from sqlalchemy.orm import defer
@@ -20,6 +18,10 @@ from app.services.theme_service import get_theme_context
 from app.services.workflow_import_service import (
     ImportacaoArquivoErro,
     process_workflow_upload,
+)
+from app.routes.analise_jp import (
+    build_analise_jp_dashboard_context,
+    build_analise_jp_charts_context,
 )
 
 workflow_bp = Blueprint('workflow', __name__)
@@ -41,26 +43,6 @@ def _serialize_arquivo_metadata(
     if include_counts:
         total_indicadores = 0
         dados_extraidos = arquivo.dados_extraidos or {}
-
-        if isinstance(dados_extraidos, dict):
-            raw_total = dados_extraidos.get('total_indicadores')
-            if isinstance(raw_total, (int, float)):
-                total_indicadores = int(raw_total)
-            else:
-                indicadores = dados_extraidos.get('indicadores')
-                if isinstance(indicadores, list):
-                    total_indicadores = len(indicadores)
-
-        metadata['total_indicadores'] = total_indicadores
-
-    return metadata
-
-    if include_counts:
-        total_indicadores = 0
-
-        dados_extraidos = arquivo.dados_extraidos or {}
-
-        dados_extraidos = arquivo.dados_extraidos
 
         if isinstance(dados_extraidos, dict):
             raw_total = dados_extraidos.get('total_indicadores')
@@ -121,6 +103,9 @@ def dashboard():
 @login_required
 def workflow_charts_view(workflow_nome):
     workflow = _get_workflow_for_user_by_name(workflow_nome)
+    if workflow.tipo == 'analise_jp':
+        context = build_analise_jp_charts_context(workflow)
+        return render_template('analise_jp_charts.html', **context)
     arquivo_atual, processed_data = _get_processed_data_for_workflow(workflow.id)
 
     theme = get_theme_context()
@@ -139,10 +124,10 @@ def workflow_view(workflow_nome):
     """Exibe a pagina do workflow selecionado."""
     workflow = _get_workflow_for_user_by_name(workflow_nome)
     if workflow.tipo == 'analise_jp':
-        return redirect(url_for('analise_jp.analise_jp_view', workflow_id=workflow.id))
+        context = build_analise_jp_dashboard_context(workflow)
+        return render_template('analise_jp.html', **context)
 
     arquivo_atual = _get_latest_file_for_workflow(workflow.id, include_payload=False)
-    arquivo_atual, processed_data = _get_processed_data_for_workflow(workflow.id)
 
     arquivo_atual_metadata = (
         _serialize_arquivo_metadata(arquivo_atual)


### PR DESCRIPTION
## Summary
- redirect legacy analise_jp dashboard and charts routes to the shared /dashboard/<workflow> endpoints for consistent URLs
- simplify workflow metadata serialization to avoid duplicated logic when deferring heavy payloads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e41755fa888321a1d83c48c27c44ac