### PR TITLE
Enable vertical scrolling on workflow charts page

### DIFF
--- a/app/templates/workflow_charts.html
+++ b/app/templates/workflow_charts.html
@@ -76,7 +76,7 @@
         }
     </style>
 </head>
-<body class="{{ theme.bg }} {{ theme.text }} font-sans min-h-screen overflow-hidden">
+<body class="{{ theme.bg }} {{ theme.text }} font-sans min-h-screen overflow-x-hidden">
     <div class="flex h-full">
         {% include 'partials/sidebar.html' %}
 


### PR DESCRIPTION
## Summary
- allow the workflow charts page to scroll vertically when content exceeds the viewport by removing the overflow block on the body element

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e527e3bc388321a301214b62fa6cdc